### PR TITLE
Updated the Dockerfile and modified the output.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-# To build:
-# $ docker run --rm -v $(pwd):/go/src/github.com/micahhausler/k8s-oidc-helper -w /go/src/github.com/micahhausler/k8s-oidc-helper golang:1.7  go build -v -a -tags netgo -installsuffix netgo -ldflags '-w'
-# $ docker build -t micahhausler/k8s-oidc-helper .
-#
-# To run:
-# $ docker run micahhausler/k8s-oidc-helper
+FROM golang:1.9
 
-FROM busybox
+MAINTAINER Chien Huey, <chuey@xogrp.com>
 
-MAINTAINER Micah Hausler, <hausler.m@gmail.com>
+RUN go get github.com/micahhausler/k8s-oidc-helper
+RUN go get github.com/ogier/pflag
+RUN go get gopkg.in/yaml.v2
+RUN go build -v -a -tags netgo -installsuffix netgo -ldflags '-w' -o /bin/k8s-oidc-helper github.com/micahhausler/k8s-oidc-helper
 
-COPY k8s-oidc-helper /bin/k8s-oidc-helper
-RUN chmod 755 /bin/k8s-oidc-helper
-
-ENTRYPOINT ["/bin/k8s-oidc-helper"]
+CMD /bin/k8s-oidc-helper

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,13 @@ ADD . $WORKDIR
 
 RUN go get github.com/ogier/pflag
 RUN go get gopkg.in/yaml.v2
-RUN go build -v -a -tags netgo -installsuffix netgo -ldflags '-w' -o /bin/k8s-oidc-helper .
+RUN CGO_ENABLED=0 go build -v -a -tags netgo -installsuffix netgo -ldflags '-w' -o /bin/k8s-oidc-helper .
 
-CMD /bin/k8s-oidc-helper
+FROM golang:1.9.0-alpine
+
+WORKDIR /bin
+
+COPY --from=0 /bin/k8s-oidc-helper .
+RUN chmod 755 /bin/k8s-oidc-helper
+
+ENTRYPOINT ["/bin/k8s-oidc-helper"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM golang:1.9
 
-MAINTAINER Chien Huey, <chuey@xogrp.com>
+MAINTAINER Micah Hausler, <hausler.m@gmail.com>
 
-RUN go get github.com/micahhausler/k8s-oidc-helper
+WORKDIR /build
+ADD . $WORKDIR
+
 RUN go get github.com/ogier/pflag
 RUN go get gopkg.in/yaml.v2
-RUN go build -v -a -tags netgo -installsuffix netgo -ldflags '-w' -o /bin/k8s-oidc-helper github.com/micahhausler/k8s-oidc-helper
+RUN go build -v -a -tags netgo -installsuffix netgo -ldflags '-w' -o /bin/k8s-oidc-helper .
 
 CMD /bin/k8s-oidc-helper

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,11 @@ RUN go get github.com/ogier/pflag
 RUN go get gopkg.in/yaml.v2
 RUN go build -v -a -tags netgo -installsuffix netgo -ldflags '-w' -o /bin/k8s-oidc-helper .
 
-CMD /bin/k8s-oidc-helper
+FROM busybox
+
+WORKDIR /bin
+
+COPY --from=0 /bin/k8s-oidc-helper .
+RUN chmod 755 /bin/k8s-oidc-helper
+
+ENTRYPOINT ["/bin/k8s-oidc-helper"]

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	flag "github.com/ogier/pflag"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const Version = "0.0.1"
@@ -228,13 +227,6 @@ func main() {
 	userConfig := generateUser(email, clientID, clientSecret, tokResponse.IdToken, tokResponse.RefreshToken)
 	output := map[string][]*KubectlUser{}
 	output["users"] = []*KubectlUser{userConfig}
-	response, err := yaml.Marshal(output)
-	if err != nil {
-		fmt.Printf("Error marshaling yaml: %s\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("\n These are your user credentials")
-	fmt.Printf("% \n", response)
 
 	// print kubectl command that automatically updates the user's kubectl config
 	fmt.Println("\n # Use this command to automatically update your ~/.kube/config")

--- a/main.go
+++ b/main.go
@@ -233,7 +233,15 @@ func main() {
 		fmt.Printf("Error marshaling yaml: %s\n", err)
 		os.Exit(1)
 	}
-	fmt.Println("\n# Add the following to your ~/.kube/config")
-	fmt.Println(string(response))
+
+	// print kubectl command that automatically updates the user's kubectl config
+	fmt.Println("\n # Use this command to automatically update your ~/.kube/config")
+	fmt.Printf("kubectl config set-credentials %s \\\n", email)
+	fmt.Println("--auth-provider=oidc \\")
+	fmt.Println("--auth-provider-arg=idp-issuer-url=https://accounts.google.com \\")
+	fmt.Printf("--auth-provider-arg=client-id=%s \\\n", clientID)
+	fmt.Printf("--auth-provider-arg=client-secret=%s \\\n", clientSecret)
+	fmt.Printf("--auth-provider-arg=refresh-token=%s \\\n", tokResponse.RefreshToken)
+	fmt.Printf("--auth-provider-arg=id-token=%s\n", tokResponse.IdToken)
 
 }

--- a/main.go
+++ b/main.go
@@ -233,6 +233,8 @@ func main() {
 		fmt.Printf("Error marshaling yaml: %s\n", err)
 		os.Exit(1)
 	}
+	fmt.Println("\n These are your user credentials")
+	fmt.Printf("% \n", response)
 
 	// print kubectl command that automatically updates the user's kubectl config
 	fmt.Println("\n # Use this command to automatically update your ~/.kube/config")


### PR DESCRIPTION
Updated the Dockerfile to where the binary is built as part of the image instead of just being copied into the container.

Modified the output to generate the kubectl config command such that it lets kubectl handle updating the `.kube/config` rather than requiring the user to copy and paste user tokens into `.kube/config`. Should minimize the chances of user messing up their `.kube/config`.