### PR TITLE
Adds ca certs to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN go install -ldflags '-w'
 
 FROM alpine:latest
 
+RUN apk add -U ca-certificates
+
 COPY --from=builder /go/bin/k8s-oidc-helper /bin/k8s-oidc-helper
 
 ENTRYPOINT ["/bin/k8s-oidc-helper"]


### PR DESCRIPTION
Lacking these certs caused errors such as
`Error getting tokens: Post https://www.googleapis.com/oauth2/v3/token:
x509: failed to load system roots and no roots provided`

This fixes #12 but it used #10 to find the root issue.  

I would recommend merging #10 as well.