### PR TITLE
Add flag for google oauth2 api version

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -42,7 +42,7 @@ func ReadConfig(path string) (*GoogleConfig, error) {
 }
 
 // Get the id_token and refresh_token from google
-func GetToken(clientID, clientSecret, code string) (*TokenResponse, error) {
+func GetToken(clientID, clientSecret, code, apiVersion string) (*TokenResponse, error) {
 	val := url.Values{}
 	val.Add("grant_type", "authorization_code")
 	val.Add("redirect_uri", "urn:ietf:wg:oauth:2.0:oob")
@@ -50,7 +50,7 @@ func GetToken(clientID, clientSecret, code string) (*TokenResponse, error) {
 	val.Add("client_secret", clientSecret)
 	val.Add("code", code)
 
-	resp, err := http.PostForm("https://www.googleapis.com/oauth2/v3/token", val)
+	resp, err := http.PostForm("https://www.googleapis.com/oauth2/" + apiVersion + "/token", val)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 	flag.StringP("config", "c", "", "Path to a json file containing your application's ClientID and ClientSecret. Supercedes the --client-id and --client-secret flags.")
 	flag.BoolP("write", "w", false, "Write config to file. Merges in the specified file")
 	flag.String("file", "", "The file to write to. If not specified, `~/.kube/config` is used")
+	flag.String("api-version", "v3", "The Google Oauth2 API version. Use v4 for k8s v1.10 or later")
 
 	viper.BindPFlags(flag.CommandLine)
 	viper.SetEnvPrefix("k8s-oidc-helper")
@@ -71,7 +72,7 @@ func main() {
 	code, _ := reader.ReadString('\n')
 	code = strings.TrimSpace(code)
 
-	tokResponse, err := helper.GetToken(clientID, clientSecret, code)
+	tokResponse, err := helper.GetToken(clientID, clientSecret, code, viper.GetString("api-version"))
 	if err != nil {
 		fmt.Printf("Error getting tokens: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
From [CHANGELOG-1.10.md](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.10.md):
> kube-apiserver: the OpenID Connect authenticator no longer accepts tokens from the Google v3 token APIs; users must switch to the "https://www.googleapis.com/oauth2/v4/token" endpoint.

If you use the token retrieved from version 3 of the api to access the k8s apiserver, kubectl will log:
 `error: You must be logged in to the server (Unauthorized)" ` 
And the following will be logged in the apiserver: 
`E0418 12:26:47.196237       1 authentication.go:63] Unable to authenticate the request due to an error: [invalid bearer token, [invalid bearer token, invalid bearer token]]`

This PR adds an "api-version" flag that defaults to "v3" for backwards compatibility. Feel free to modify it as you like before merging.
