### PR TITLE
Add error messages on confusing config content

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -38,6 +38,12 @@ func ReadConfig(path string) (*GoogleConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	if cf.Installed == nil {
+		return nil, fmt.Errorf("config file has no 'installed' section; wrong client type?")
+	}
+	if cf.Installed.ClientID == "" {
+		return nil, fmt.Errorf("config file had no client_id defined; wrong client type?")
+	}
 	return cf.Installed, nil
 }
 


### PR DESCRIPTION
Using k8s-oidc-helper with a wrong client type will lead to confusing
errors when auth is attempted.  While this is technically correct, it's
probably a good idea to be a bit more user friendly and tell the user
what may be wrong.