### PR TITLE
 Change references to internal repo from public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.9-alpine as builder
 
 RUN apk add -U ca-certificates
 
-ENV PKG=/go/src/github.com/micahhausler/k8s-oidc-helper
+ENV PKG=/go/src/github.com/smooch/k8s-oidc-helper
 ADD . $PKG
 WORKDIR $PKG
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Docker Build Status](https://img.shields.io/docker/build/micahhausler/k8s-oidc-helper.svg)](https://hub.docker.com/r/micahhausler/k8s-oidc-helper/)
-[![Build Status](https://travis-ci.org/micahhausler/k8s-oidc-helper.svg?branch=master)](https://travis-ci.org/micahhausler/k8s-oidc-helper)
+[![Docker Build Status](https://img.shields.io/docker/build/smooch/k8s-oidc-helper.svg)](https://hub.docker.com/r/smooch/k8s-oidc-helper/)
+[![Build Status](https://travis-ci.org/smooch/k8s-oidc-helper.svg?branch=master)](https://travis-ci.org/smooch/k8s-oidc-helper)
 
 # k8s-oidc-helper
 
@@ -92,7 +92,7 @@ roleRef:
 ## Installation
 
 ```
-go get github.com/micahhausler/k8s-oidc-helper
+go get github.com/smooch/k8s-oidc-helper
 ```
 
 ## Usage

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -50,7 +50,7 @@ func GetToken(clientID, clientSecret, code string) (*TokenResponse, error) {
 	val.Add("client_secret", clientSecret)
 	val.Add("code", code)
 
-	resp, err := http.PostForm("https://www.googleapis.com/oauth2/v3/token", val)
+	resp, err := http.PostForm("https://www.googleapis.com/oauth2/v4/token", val)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/micahhausler/k8s-oidc-helper/internal/helper"
+	"github.com/smooch/k8s-oidc-helper/internal/helper"
 	flag "github.com/spf13/pflag"
 	viper "github.com/spf13/viper"
 	k8s_runtime "k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
In attempt to solve:

```...go/src/github.com/smooch/k8s-oidc-helper/main.go:13:2: use of internal package github.com/micahhausler/k8s-oidc-helper/internal/helper not allowed```

Important change : https://github.com/micahhausler/k8s-oidc-helper/compare/master...smooch:f/fix-v4?expand=1#diff-7ddfb3e035b42cd70649cc33393fe32c

